### PR TITLE
Implement Integrity Checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ translation-files
 build/
 dist/
 *.egg-info
+venv/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ in CD ripping logs.
   - Irregular AR results
   - Hidden tracks and extraction
 - Foreign language support (temperamental, as it's based on the most recent translation files).
+- Checks integrity of EAC logs.
 
 ## Running CLI
 

--- a/heybrochecklog/__init__.py
+++ b/heybrochecklog/__init__.py
@@ -33,13 +33,6 @@ def parse_args():
         help='Only print the score of the log.',
         action='store_true',
     )
-    parser.add_argument(
-        '-v',
-        '--version',
-        help='Print version info.',
-        action='version',
-        version='1.3.3-doujinmusicdiscord'
-    )
 
     return parser.parse_args()
 

--- a/heybrochecklog/logfile.py
+++ b/heybrochecklog/logfile.py
@@ -9,7 +9,7 @@ class LogFile:
     """A log file class containing variables, score, deductions, etc."""
 
     def __init__(self, contents, ripper=None):
-
+        self.raw_cock = False
         self.full_contents = contents
         self.contents = format_full_contents(contents)
         self.concat_contents = [line for line in self.contents if line.strip()]

--- a/heybrochecklog/logfile.py
+++ b/heybrochecklog/logfile.py
@@ -9,7 +9,7 @@ class LogFile:
     """A log file class containing variables, score, deductions, etc."""
 
     def __init__(self, contents, ripper=None):
-        self.raw_cock = False
+        self.invalid_checksum = False
         self.full_contents = contents
         self.contents = format_full_contents(contents)
         self.concat_contents = [line for line in self.contents if line.strip()]

--- a/heybrochecklog/score/eac.py
+++ b/heybrochecklog/score/eac.py
@@ -153,8 +153,8 @@ class EACChecker(LogChecker):
     def validate_integrity(self, log):
         log_concat = str.join("", log.full_contents)
         result = check_integrity(log_concat)
-        if result == "LOG_NOT_OK_RETARD":
-            log.raw_cock = True
+        if result == "LOG_NOT_OK":
+            log.invalid_checksum = True
 
     def deduct_and_score(self, log):
         """Process the accumulated deductions and score the log file."""

--- a/heybrochecklog/score/eac.py
+++ b/heybrochecklog/score/eac.py
@@ -7,6 +7,7 @@ from heybrochecklog.markup import markup
 from heybrochecklog.score.logchecker import LogChecker
 from heybrochecklog.score.modules import combined, parsers, validation
 from heybrochecklog.shared import format_pattern as fmt_ptn
+from heybrochecklog.score.integrity import check_integrity
 
 
 class EACChecker(LogChecker):
@@ -28,6 +29,7 @@ class EACChecker(LogChecker):
             parsers.index_toc(log)
             self.is_there_a_htoa(log)
             self.check_tracks(log)
+            self.validate_integrity(log)
             parsers.parse_checksum(
                 log, self.patterns['checksum'], 'V1.0 beta 1', 'EAC <1.0'
             )
@@ -147,6 +149,12 @@ class EACChecker(LogChecker):
                 log.add_deduction('Range rip')
             # Check AccurateRip - Mismatching AR results can indicate problems even with T&C
             validation.analyze_accuraterip(log)
+
+    def validate_integrity(self, log):
+        log_concat = str.join("", log.full_contents)
+        result = check_integrity(log_concat)
+        if result == "LOG_NOT_OK_RETARD":
+            log.raw_cock = True
 
     def deduct_and_score(self, log):
         """Process the accumulated deductions and score the log file."""

--- a/heybrochecklog/score/integrity.py
+++ b/heybrochecklog/score/integrity.py
@@ -93,4 +93,4 @@ def check_integrity(text):
     if old_signature == actual_signature:
         return "LOG_OK"
 
-    return "LOG_NOT_OK_RETARD"
+    return "LOG_NOT_OK"

--- a/heybrochecklog/score/integrity.py
+++ b/heybrochecklog/score/integrity.py
@@ -37,13 +37,25 @@ def eac_checksum(text):
         signature = cipher.encrypt(cbc_plaintext)
 
     # Textual signature is just the hex representation
-    return bytes(signature, "utf-16-le").hex().upper().replace('00', '')
+    chunks = chunk_string((bytes(signature, "utf-16-le").hex().upper()), 4)
+    chunk_result = list()
+    for i in chunks:
+        if i.endswith('00'):
+            chunk_result.append(i[:-2])
+
+    return str.join("", chunk_result)
+
+
+def chunk_string(string, length):
+    return (string[0 + i:length + i] for i in range(0, len(string), length))
+
 
 def ord_or_int(data):
     if type(data) is int:
         return data
 
     return ord(data)
+
 
 def extract_info(text):
     if '\r\n\r\n==== Log checksum' not in text:
@@ -69,7 +81,7 @@ def eac_verify(text):
 
 
 def check_integrity(text):
-    text = text.replace('\n', '\r\n') # dunno
+    text = text.replace('\n', '\r\n')  # dunno
     old_signature, actual_signature = eac_verify(text)
 
     print(old_signature)

--- a/heybrochecklog/score/integrity.py
+++ b/heybrochecklog/score/integrity.py
@@ -84,9 +84,6 @@ def check_integrity(text):
     text = text.replace('\n', '\r\n')  # dunno
     old_signature, actual_signature = eac_verify(text)
 
-    print(old_signature)
-    print(actual_signature)
-
     if old_signature is None:
         return "LOG_CHECKSUM_NOT_PRESENT"
 

--- a/heybrochecklog/score/integrity.py
+++ b/heybrochecklog/score/integrity.py
@@ -1,0 +1,84 @@
+# Log Integrity Checker
+# Glorified modification to make use of latest pprp and python 3.9 :)
+# Source from https://github.com/puddly/eac_logsigner/blob/master/eac.py
+
+import pprp
+
+
+def eac_checksum(text):
+    # Ignore newlines
+    text = text.replace('\r', '').replace('\n', '')
+
+    # Fuzzing reveals BOMs are also ignored
+    text = text.replace('\ufeff', '').replace('\ufffe', '')
+
+    # Setup Rijndael-256 with a 256-bit blocksize
+    cipher = pprp.crypto.rijndael(
+        # Probably SHA256('super secret password') but it doesn't actually matter
+        key=bytes.fromhex('9378716cf13e4265ae55338e940b376184da389e50647726b35f6f341ee3efd9'),
+        block_size=256 // 8
+    )
+
+    # Encode the text as UTF-16-LE
+    plaintext = text.encode('utf-16-le')
+
+    # The IV is all zeroes so we don't have to handle it
+    signature = b'\x00' * 32
+
+    # Process it block-by-block
+    for i in range(0, len(plaintext), 32):
+        # Zero-pad the last block, if necessary
+        plaintext_block = plaintext[i:i + 32].ljust(32, b'\x00')
+
+        # CBC mode (XOR the previous ciphertext block into the plaintext)
+        cbc_plaintext = bytes((ord_or_int(a)) ^ (ord_or_int(b)) for a, b in zip(signature, plaintext_block))
+
+        # New signature is the ciphertext.
+        signature = cipher.encrypt(cbc_plaintext)
+
+    # Textual signature is just the hex representation
+    return bytes(signature, "utf-16-le").hex().upper().replace('00', '')
+
+def ord_or_int(data):
+    if type(data) is int:
+        return data
+
+    return ord(data)
+
+def extract_info(text):
+    if '\r\n\r\n==== Log checksum' not in text:
+        signature = None
+    else:
+        text, signature_parts = text.split('\r\n\r\n==== Log checksum', 1)
+        signature = signature_parts.split()[0].strip()
+
+    return text, signature
+
+
+def eac_verify(text):
+    # Strip off BOM
+    if text.startswith('\ufeff'):
+        text = text[1:]
+
+    # Null bytes screw it up
+    if '\x00' in text:
+        text = text[:text.index('\x00')]
+
+    unsigned_text, old_signature = extract_info(text)
+    return old_signature, eac_checksum(unsigned_text)
+
+
+def check_integrity(text):
+    text = text.replace('\n', '\r\n') # dunno
+    old_signature, actual_signature = eac_verify(text)
+
+    print(old_signature)
+    print(actual_signature)
+
+    if old_signature is None:
+        return "LOG_CHECKSUM_NOT_PRESENT"
+
+    if old_signature == actual_signature:
+        return "LOG_OK"
+
+    return "LOG_NOT_OK_RETARD"

--- a/heybrochecklog/score/logchecker.py
+++ b/heybrochecklog/score/logchecker.py
@@ -174,6 +174,6 @@ class LogChecker:
             [de[1] for de in log.deductions.values() if isinstance(de[1], int)]
         )
 
-        if log.raw_cock:
+        if log.invalid_checksum:
             log.add_deduction('Invalid Checksum. (All Points)')
             log.score = 0

--- a/heybrochecklog/score/logchecker.py
+++ b/heybrochecklog/score/logchecker.py
@@ -173,3 +173,7 @@ class LogChecker:
         log.score -= sum(
             [de[1] for de in log.deductions.values() if isinstance(de[1], int)]
         )
+
+        if log.raw_cock:
+            log.add_deduction('Invalid Checksum Retard. (All Points)')
+            log.score = 0

--- a/heybrochecklog/score/logchecker.py
+++ b/heybrochecklog/score/logchecker.py
@@ -175,5 +175,5 @@ class LogChecker:
         )
 
         if log.raw_cock:
-            log.add_deduction('Invalid Checksum Retard. (All Points)')
+            log.add_deduction('Invalid Checksum. (All Points)')
             log.score = 0

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,8 +37,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "coverage"
+version = "5.5"
+description = "Code coverage measurement for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 name = "importlib-metadata"
-version = "2.0.0"
+version = "2.1.1"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -49,19 +60,27 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "more-itertools"
-version = "8.6.0"
+version = "8.7.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "nose"
+version = "1.3.7"
+description = "nose extends unittest to make testing easier"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
-version = "20.4"
+version = "20.9"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
@@ -69,7 +88,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
-six = "*"
 
 [[package]]
 name = "pathlib2"
@@ -97,8 +115,20 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "pprp"
+version = "0.2.7"
+description = "A pure-Python Rijndael (AES) and PBKDF2 library. Python 2.7 and Python3 compatible."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+coverage = ">=4.4.1"
+nose = ">=1.3.7"
+
+[[package]]
 name = "py"
-version = "1.9.0"
+version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
@@ -167,7 +197,7 @@ testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.5"
-content-hash = "858d7438c82189b7845f7bd34a96cbe56f7b48544ea3e5fb9d4796e637227d6e"
+content-hash = "28359e962522f41fce210b2807e654f320b9c8b0a889f2e78439f1944884ce8e"
 
 [metadata.files]
 atomicwrites = [
@@ -213,17 +243,76 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+coverage = [
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
+]
 importlib-metadata = [
-    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
-    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
+    {file = "importlib_metadata-2.1.1-py2.py3-none-any.whl", hash = "sha256:c2d6341ff566f609e89a2acb2db190e5e1d23d5409d6cc8d2fe34d72443876d4"},
+    {file = "importlib_metadata-2.1.1.tar.gz", hash = "sha256:b8de9eff2b35fb037368f28a7df1df4e6436f578fa74423505b6c6a778d5b5dd"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
-    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
+    {file = "more-itertools-8.7.0.tar.gz", hash = "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"},
+    {file = "more_itertools-8.7.0-py3-none-any.whl", hash = "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced"},
+]
+nose = [
+    {file = "nose-1.3.7-py2-none-any.whl", hash = "sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a"},
+    {file = "nose-1.3.7-py3-none-any.whl", hash = "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac"},
+    {file = "nose-1.3.7.tar.gz", hash = "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"},
 ]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pathlib2 = [
     {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
@@ -233,9 +322,12 @@ pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
+pprp = [
+    {file = "pprp-0.2.7.tar.gz", hash = "sha256:d9e76779cc52b0938dbc7f5727a195dc4c6075c3eb504025611a59b7636b930d"},
+]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ heybrochecklog = 'heybrochecklog.__main__:runner'
 [tool.poetry.dependencies]
 python = "^3.5"
 cchardet = "^2.1.7"
+pprp = "^0.2.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "heybrochecklog"
-version = "1.3.3"
+version = "1.4.0"
 description = "A python tool for evaluating and working with EAC/XLD rip logs."
 authors = ["lights <lights@tutanota.de>"]
 license = "Apache-2.0"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name='heybrochecklog',
-    version='1.3.3',
+    version='1.4.0',
     description='A python tool for evaluating and working with EAC/XLD rip logs.',
     python_requires='==3.*,>=3.5.0',
     project_urls={"repository": "https://github.com/ligh7s/hey-bro-check-log"},
@@ -46,6 +46,6 @@ setup(
             "*.db", "*.json", "eac/*.json", "eac95/*.json"
         ]
     },
-    install_requires=['cchardet>=2.1.7'],
+    install_requires=['cchardet>=2.1.7', 'pprp>=0.2.7'],
     extras_require={"dev": ["pytest==5.*,>=5.3.5"]},
 )


### PR DESCRIPTION
Implements Integrity Checking for your logs. Any wrong integrity will automatically make the score of your log to 0. This won't affect logs without checksums.