### PR TITLE
Update regex for alternative AccurateRip matches

### DIFF
--- a/heybrochecklog/resources/xld.json
+++ b/heybrochecklog/resources/xld.json
@@ -31,7 +31,7 @@
     },
     "accuraterip": {
         "match": [
-            "->Accurately ripped!? \\((?:[v12,+]+ )?confidence ([0-9\\/+]+)\\)",
+            "->Accurately ripped!? \\((?:(AR)?[v12,+]+ )?confidence ([0-9\\/+]+)\\)",
             "->Accurately ripped!? (with different offset \\(v\\d, confidence \\d\\/\\d, offset -?\\d+\\))"
         ],
         "no match": ["->Track not present in AccurateRip database"]


### PR DESCRIPTION
Similar to #5, log that scores 100% on RED/OPS is scoring 95% with `>>  AccurateRip was not enabled (-5 points)`. This just modifies the XLD AccurateRip regex to match when the version is prefixed with `AR`, such as AR2. The regex is already kinda loose with accepting any order of characters with `[v12,+]+`, it could be worth making more specific but for now this just works.

Log that prompted this change: 
[Hooverphonic - The Night Before.log](https://github.com/user-attachments/files/16923416/Hooverphonic.-.The.Night.Before.log)
