### PR TITLE
Fix multiple pattern matching from translation files

### DIFF
--- a/heybrochecklog/score/logchecker.py
+++ b/heybrochecklog/score/logchecker.py
@@ -7,7 +7,7 @@ import re
 from heybrochecklog import UnrecognizedException
 from heybrochecklog.resources import VERSIONS
 from heybrochecklog.score.modules import drives, parsers, validation
-from heybrochecklog.shared import format_pattern as fmt_ptn
+from heybrochecklog.shared import format_pattern as fmt_ptn, format_pattern_for_setting_evaluation as fmt_ptn_setting
 
 
 class LogChecker:
@@ -93,7 +93,7 @@ class LogChecker:
         settings = {}
         colon = r' : (.*)' if log.language == 'english' else r'(?: :)? : (.*)'
         for key, setting in psettings.items():
-            settings[key] = re.compile(fmt_ptn(setting) + colon)
+            settings[key] = re.compile(fmt_ptn_setting(setting) + colon)
 
         # Iterate through line in the settings, and verify each setting in `sets` dict
         for line in log.contents[log.index_settings : log.index_toc]:

--- a/heybrochecklog/shared.py
+++ b/heybrochecklog/shared.py
@@ -48,6 +48,10 @@ def format_pattern(pattern, append=None):
     return '|'.join(pattern)
 
 
+def format_pattern_for_setting_evaluation(pattern):
+    return '(?:{})'.format('|'.join(pattern))
+
+
 def open_json(*paths):
     """Open the language JSON patterns file and return it."""
     basepath = get_path()


### PR DESCRIPTION
This is a tiny change so that existing translation files will work when providing multiple possible patterns. Discovered when trying to score Russian logs that use the [alternative string](https://github.com/doujincafe/hbcl/blob/c02984e3fa9cb676f15486d217e3fba9190c5762/heybrochecklog/resources/eac/russian.json#L15) for ID3 tags being added.

This change means the pattern matching is changed from
`re.compile('Добавление ID3-тега|Добавление ID3-тэга(?: :)? : (.*)')`
to
`re.compile('(?:Добавление ID3-тега|Добавление ID3-тэга)(?: :)? : (.*)')`
which properly uses the OR operator in the regex without excluding the colon from the first pattern.

Here is a selection of logs that was tested with. They do not work with the current version.
[russian.zip](https://github.com/user-attachments/files/19102185/russian.zip)

