### PR TITLE
fix: wrong replace when get sign hex

### DIFF
--- a/heybrochecklog/score/integrity.py
+++ b/heybrochecklog/score/integrity.py
@@ -36,8 +36,14 @@ def eac_checksum(text):
         # New signature is the ciphertext.
         signature = cipher.encrypt(cbc_plaintext)
 
+    raw_signature = bytes(signature, "utf-16-le").hex().upper()
+    signature = ""
+
+    for i in range(0, len(raw_signature), 4):
+        signature += raw_signature[i:i + 2]
+
     # Textual signature is just the hex representation
-    return bytes(signature, "utf-16-le").hex().upper().replace('00', '')
+    return signature
 
 
 def ord_or_int(data):


### PR DESCRIPTION
When calculate EAC log's checksum, it will turn bytes into hex then replace all `00` because of utf-16, but sometimes checksum can have `00`, and it will be wrong.

Here is an example: 
[Static World, bunny_rhyTHm - 冰空夏日葵 -Frozen Sky Sunflower-.log](https://github.com/user-attachments/files/20118722/Static.World.bunny_rhyTHm.-.-Frozen.Sky.Sunflower-.log)
